### PR TITLE
Built-in API for events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ spec/examples.txt
 spec/setup/
 spec/tmp/
 .byebug_history
+log/
+spec/log/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+- [feature] Built-in sinatra APP with events API
+
 ## 0.2.0 (2016-09-06)
+
 - [feature] New CLI command to generate migrations #6
 - [feature] Automatically sets database pool size based on listeners max_concurrency #2
 
 ## 0.1.1 (2016-09-02)
+
 - [bugfix] Handler is not injecting start and stop methods #4
 
 ## 0.1.0 (2016-08-29)
+
 - Published on Github

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Phobos DB Checkpoint is a plugin to [Phobos](https://github.com/klarna/phobos) a
   1. [Setup](#setup)
   1. [Handler](#handler)
   1. [Accessing the events](#accessing-the-events)
+  1. [Events API](#events-api)
   1. [Instrumentation](#instrumentation)
 1. [Development](#development)
 
@@ -121,6 +122,46 @@ Note that the `PhobosDBCheckpoint::Handler` will automatically skip already hand
 ### <a name="accessing-the-events">Accessing the events</a>
 
 `PhobosDBCheckpoint::Event` is a plain `ActiveRecord::Base` model, feel free to play with it.
+
+### <a name="events-api"></a> Events API
+
+Phobos DB Checkpoint comes with a sinatra app which makes the event manipulation easy through its JSON API.
+
+The __init_events_api__ command will generate a `config.ru` ready to use:
+
+```sh
+$ phobos_db_checkpoint init_events_api
+   create  config.ru
+   Start the API with: `rackup config.ru`
+```
+
+```sh
+$ curl "http://localhost:9292/v1/events/1"
+# {
+#   "id": 1,
+#   "topic": "test-partitions",
+#   "group_id": "test-checkpoint-1",
+#   "entity_id": "1",
+#   "event_time": "2016-09-19T19:35:26.854Z",
+#   "event_type": "create",
+#   "event_version": "v1",
+#   "checksum": "188773471ec0f898fd81d272760a027f",
+#   "payload": "{\"a\":\"b\"}"
+# }
+```
+
+The available routes are:
+
+* GET `/ping`
+* GET `/v1/events/:id`
+* GET `/v1/events` This route accepts the following params:
+  * `limit`, default: 20
+  * `offset`, default: 0
+  * `entity_id`
+  * `topic`
+  * `group_id`
+  * `event_type`
+* POST `/v1/events/:id/retry`
 
 ### <a name="instrumentation"></a> Instrumentation
 

--- a/lib/phobos_db_checkpoint/cli.rb
+++ b/lib/phobos_db_checkpoint/cli.rb
@@ -66,6 +66,12 @@ module PhobosDBCheckpoint
         template(new_migration_template, destination_fullpath)
       end
 
+      desc 'init-events-api', 'Initialize your project with events API'
+      def init_events_api
+        copy_file 'templates/config.ru', 'config.ru'
+        say '   Start the API with: `rackup config.ru`'
+      end
+
       def self.source_root
         File.expand_path(File.join(File.dirname(__FILE__), '../..'))
       end

--- a/lib/phobos_db_checkpoint/event.rb
+++ b/lib/phobos_db_checkpoint/event.rb
@@ -14,6 +14,14 @@ module PhobosDBCheckpoint
       save!
     end
 
+    def configured_handler
+      Phobos
+        .config
+        .listeners
+        .find { |listener| listener.group_id == self.group_id }
+        &.handler
+    end
+
     private
 
     def assign_checksum

--- a/lib/phobos_db_checkpoint/events_api.rb
+++ b/lib/phobos_db_checkpoint/events_api.rb
@@ -1,0 +1,76 @@
+require 'json'
+require 'rack'
+require 'sinatra/base'
+
+require 'phobos_db_checkpoint/middleware/logger'
+require 'phobos_db_checkpoint/middleware/database'
+
+module PhobosDBCheckpoint
+  class EventsAPI < Sinatra::Base
+    VERSION = :v1
+    set :logging, nil
+
+    not_found do
+      content_type :json
+      { error: true, message: 'not found' }.to_json
+    end
+
+    error ActiveRecord::RecordNotFound do
+      content_type :json
+      status 404
+      { error: true, message: 'event not found' }.to_json
+    end
+
+    error do
+      content_type :json
+      error = env['sinatra.error']
+      { error: true, message: error.message }.to_json
+    end
+
+    get '/ping' do
+      'PONG'
+    end
+
+    get "/#{VERSION}/events/:id" do
+      content_type :json
+      PhobosDBCheckpoint::Event
+        .find(params['id'])
+        .to_json
+    end
+
+    post "/#{VERSION}/events/:id/retry" do
+      content_type :json
+      event = PhobosDBCheckpoint::Event.find(params['id'])
+      handler_name = event.configured_handler
+
+      unless handler_name
+        status 422
+        return { error: true, message: 'no handler configured for this event' }.to_json
+      end
+
+      handler_class = handler_name.constantize
+      metadata = { listener_id: 'events_api/retry', group_id: event.group_id, topic: event.topic, retry_count: 0 }
+      event_action = handler_class.new.consume(event.payload, metadata)
+
+      { acknowledged: event_action.is_a?(PhobosDBCheckpoint::Ack) }.to_json
+    end
+
+    get "/#{VERSION}/events" do
+      content_type :json
+      limit = (params['limit'] || 20).to_i
+      offset = (params['offset'] || 0).to_i
+
+      query = PhobosDBCheckpoint::Event
+      query = query.where(topic: params['topic']) if params['topic']
+      query = query.where(group_id: params['group_id']) if params['group_id']
+      query = query.where(entity_id: params['entity_id']) if params['entity_id']
+      query = query.where(event_type: params['event_type']) if params['event_type']
+
+      query
+        .order(event_time: :desc)
+        .limit(limit)
+        .offset(offset)
+        .to_json
+    end
+  end
+end

--- a/lib/phobos_db_checkpoint/events_api.rb
+++ b/lib/phobos_db_checkpoint/events_api.rb
@@ -21,7 +21,7 @@ module PhobosDBCheckpoint
       { error: true, message: 'event not found' }.to_json
     end
 
-    error do
+    error StandardError do
       content_type :json
       error = env['sinatra.error']
       { error: true, message: error.message }.to_json

--- a/lib/phobos_db_checkpoint/middleware/database.rb
+++ b/lib/phobos_db_checkpoint/middleware/database.rb
@@ -1,0 +1,20 @@
+module PhobosDBCheckpoint
+  module Middleware
+    class Database
+
+      def initialize(app, options = {})
+        @app = app
+        pool_size = options.fetch(:pool_size, PhobosDBCheckpoint::DEFAULT_POOL_SIZE)
+        PhobosDBCheckpoint.configure(pool_size: pool_size)
+      end
+
+      def call(request_env)
+        ActiveRecord::Base.connection_pool.with_connection do
+          @app.call(request_env)
+        end
+      ensure
+        ActiveRecord::Base.clear_active_connections!
+      end
+    end
+  end
+end

--- a/lib/phobos_db_checkpoint/middleware/logger.rb
+++ b/lib/phobos_db_checkpoint/middleware/logger.rb
@@ -1,0 +1,68 @@
+require 'rack'
+
+module PhobosDBCheckpoint
+  module Middleware
+    class Logger
+      RACK_LOGGER    = 'rack.logger'.freeze
+      SINATRA_ERROR  = 'sinatra.error'.freeze
+      HTTP_VERSION   = 'HTTP_VERSION'.freeze
+      PATH_INFO      = 'PATH_INFO'.freeze
+      REQUEST_METHOD = 'REQUEST_METHOD'.freeze
+      QUERY_STRING   = 'QUERY_STRING'.freeze
+      CONTENT_LENGTH = 'Content-Length'.freeze
+
+      def initialize(app, options = {})
+        @app = app
+        Phobos.configure(options.fetch(:config, 'config/phobos.yml'))
+        Phobos.config.logger.file = options.fetch(:log_file, 'log/api.log')
+        Phobos.configure_logger
+        ActiveRecord::Base.logger = Phobos.logger
+      end
+
+      def call(request_env)
+        began_at = Time.now
+        request_env[RACK_LOGGER] = Phobos.logger
+        status, header, body = @app.call(request_env)
+        header = Rack::Utils::HeaderHash.new(header)
+        body = Rack::BodyProxy.new(body) do
+          log(request_env, status, header, began_at)
+        end
+        [status, header, body]
+      end
+
+      private
+
+      def log(request_env, status, header, began_at)
+        error = request_env[SINATRA_ERROR]
+        message = {
+          remote_address: request_env['HTTP_X_FORWARDED_FOR'] || request_env['REMOTE_ADDR'],
+          remote_user: request_env['REMOTE_USER'],
+          request_method: request_env[REQUEST_METHOD],
+          path: extract_path(request_env),
+          status: status.to_s[0..3],
+          content_length: extract_content_length(header),
+          request_time: "#{Time.now - began_at}s"
+        }
+
+        if error
+          Phobos.logger.error(message.merge(
+            exception_class: error.class.to_s,
+            exception_message: error.message,
+            backtrace: error.backtrace
+          ))
+        else
+          Phobos.logger.info(message)
+        end
+      end
+
+      def extract_path(request_env)
+        "#{request_env[PATH_INFO]}#{request_env[QUERY_STRING].empty? ? "" : "?#{request_env[QUERY_STRING]}"} #{request_env[HTTP_VERSION]}"
+      end
+
+      def extract_content_length(headers)
+        value = headers[CONTENT_LENGTH] or return
+        value.to_s == '0' ? nil : value
+      end
+    end
+  end
+end

--- a/phobos_db_checkpoint.gemspec
+++ b/phobos_db_checkpoint.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pg'
   spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'rspec_junit_formatter', '0.2.2'
+  spec.add_development_dependency 'rack-test'
 
   spec.add_dependency 'thor'
   spec.add_dependency 'rake'

--- a/phobos_db_checkpoint.gemspec
+++ b/phobos_db_checkpoint.gemspec
@@ -56,4 +56,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rake'
   spec.add_dependency 'activerecord', '>= 4.0.0'
   spec.add_dependency 'phobos', '>= 1.0.0'
+  spec.add_dependency 'sinatra'
 end

--- a/spec/lib/phobos_db_checkpoint/cli_spec.rb
+++ b/spec/lib/phobos_db_checkpoint/cli_spec.rb
@@ -91,4 +91,19 @@ RSpec.describe PhobosDBCheckpoint::CLI do
       expect(File.read(migration_path)).to match('class AddNewColumn < ActiveRecord::Migration')
     end
   end
+
+  describe '$ phobos_db_checkpoint init-events-api' do
+    let(:invoke_cmd) do
+      cmd = PhobosDBCheckpoint::CLI::Commands.new
+      cmd.destination_root = destination_root
+      cmd.invoke(:init_events_api)
+    end
+
+    it 'copy config.ru to root' do
+      invoke_cmd
+      expect(File.exists?('spec/tmp/config.ru')).to eql true
+      expect(File.read(File.join(destination_root, 'config.ru')))
+        .to eql File.read(File.join(root, 'templates/config.ru'))
+    end
+  end
 end

--- a/spec/lib/phobos_db_checkpoint/event_spec.rb
+++ b/spec/lib/phobos_db_checkpoint/event_spec.rb
@@ -32,4 +32,16 @@ describe PhobosDBCheckpoint::Event, type: :db do
       expect(event.exists?).to eql true
     end
   end
+
+  describe '#configured_handler' do
+    before do
+      Phobos.silence_log = true
+      Phobos.configure('spec/phobos.test.yml')
+    end
+
+    it 'returns the name of the configured handler for this event' do
+      event = PhobosDBCheckpoint::Event.new(group_id: 'test-checkpoint')
+      expect(event.configured_handler).to eql Phobos::EchoHandler.to_s
+    end
+  end
 end

--- a/spec/lib/phobos_db_checkpoint/events_api_spec.rb
+++ b/spec/lib/phobos_db_checkpoint/events_api_spec.rb
@@ -1,0 +1,172 @@
+require 'spec_helper'
+require 'rack/test'
+require 'phobos_db_checkpoint/events_api'
+
+describe PhobosDBCheckpoint::EventsAPI, type: :db do
+  include Rack::Test::Methods
+
+  def app
+    PhobosDBCheckpoint::EventsAPI
+  end
+
+  def create_event(entity_id: SecureRandom.uuid, event_type: 'event-type', topic: 'test', group_id: 'test-checkpoint', event_time: Time.now, payload: {})
+    PhobosDBCheckpoint::Event.create(
+      topic: topic,
+      group_id: group_id,
+      entity_id: entity_id,
+      event_type: event_type,
+      event_time: event_time,
+      payload: {data: SecureRandom.uuid}.merge(payload).to_json
+    )
+  end
+
+  let!(:event) { create_event }
+
+  before do
+    Phobos.silence_log = true
+    Phobos.configure('spec/phobos.test.yml')
+  end
+
+  describe 'GET /ping' do
+    it 'returns pong' do
+      get '/ping'
+      expect(last_response.body).to eql 'PONG'
+    end
+  end
+
+  describe 'GET /v1/events/:id' do
+    it 'returns event json' do
+      get "/v1/events/#{event.id}"
+      expect(last_response.body).to eql event.to_json
+    end
+
+    context 'when the event does not exist' do
+      it 'returns 404' do
+        get "/v1/events/not-found"
+        expect(last_response.status).to eql 404
+        expect(last_response.body).to eql Hash(error: true, message: 'event not found').to_json
+      end
+    end
+  end
+
+  describe 'POST /v1/events/:id/retry' do
+    let(:handler) { Phobos::EchoHandler.new }
+    let :ack do
+      PhobosDBCheckpoint::Ack.new(SecureRandom.uuid, Time.now, nil, nil)
+    end
+
+    before do
+      allow(Phobos::EchoHandler).to receive(:new).and_return(handler)
+    end
+
+    it 'calls the configured handler with event payload' do
+      expect(handler)
+        .to receive(:consume)
+        .with(event.payload, hash_including(topic: event.topic, group_id: event.group_id, retry_count: 0))
+        .and_return(ack)
+
+      post "/v1/events/#{event.id}/retry"
+      expect(last_response.body).to eql Hash(acknowledged: true).to_json
+    end
+
+    context 'when handler returns something different than PhobosDBCheckpoint::Ack' do
+      it 'returns acknowledged false' do
+        expect(handler)
+          .to receive(:consume)
+          .and_return('not-ack')
+
+        post "/v1/events/#{event.id}/retry"
+        expect(last_response.body).to eql Hash(acknowledged: false).to_json
+      end
+    end
+
+    context 'when handler is configured anymore' do
+      it 'returns 422' do
+        event.group_id = 'another-group'
+        event.save
+
+        post "/v1/events/#{event.id}/retry"
+        expect(last_response.status).to eql 422
+        expect(last_response.body).to eql Hash(error: true, message: 'no handler configured for this event').to_json
+      end
+    end
+
+    context 'when the event does not exist' do
+      it 'returns 404' do
+        post "/v1/events/not-found/retry"
+        expect(last_response.status).to eql 404
+        expect(last_response.body).to eql Hash(error: true, message: 'event not found').to_json
+      end
+    end
+  end
+
+  describe 'GET /v1/events' do
+    before do
+      event.delete
+      create_event(entity_id: '1', payload: {mark: '|A|'}, topic: 'test2', event_type: 'special')
+      create_event(entity_id: '1', payload: {mark: '|B|'}, event_time: Time.now + 1000)
+      create_event(entity_id: '2', payload: {mark: '|C|'}, event_time: Time.now + 2000)
+    end
+
+    context 'when called without arguments' do
+      it 'returns the X most recent events' do
+        get '/v1/events?limit=2'
+        body = last_response.body
+        expect(JSON.parse(body).length).to eql 2
+        expect(body).to include '|B|'
+        expect(body).to include '|C|'
+        expect(body).to_not include '|A|'
+      end
+    end
+
+    context 'when called with "offset"' do
+      it 'returns the X most recent events in the correct offset' do
+        get '/v1/events?limit=2&offset=2'
+        body = last_response.body
+        expect(JSON.parse(body).length).to eql 1
+        expect(body).to_not include '|B|'
+        expect(body).to_not include '|C|'
+        expect(body).to include '|A|'
+      end
+    end
+
+    context 'when called with "entity_id"' do
+      it 'returns the X most recent events filtered by entity_id' do
+        get '/v1/events?limit=100&entity_id=1'
+        body = last_response.body
+        expect(JSON.parse(body).length).to eql 2
+        expect(body).to include '|A|'
+        expect(body).to include '|B|'
+      end
+    end
+
+    context 'when called with "topic"' do
+      it 'returns the X most recent events filtered by topic' do
+        get '/v1/events?limit=100&topic=test2'
+        body = last_response.body
+        expect(JSON.parse(body).length).to eql 1
+        expect(body).to include '|A|'
+      end
+    end
+
+    context 'when called with "group_id"' do
+      it 'returns the X most recent events filtered by group_id' do
+        get '/v1/events?limit=100&group_id=test-checkpoint'
+        body = last_response.body
+        expect(JSON.parse(body).length).to eql 3
+        expect(body).to include '|A|'
+        expect(body).to include '|B|'
+        expect(body).to include '|C|'
+      end
+    end
+
+    context 'when called with "event_type"' do
+      it 'returns the X most recent events filtered by event_type' do
+        get '/v1/events?limit=100&event_type=special'
+        body = last_response.body
+        expect(JSON.parse(body).length).to eql 1
+        expect(body).to include '|A|'
+      end
+    end
+  end
+end

--- a/spec/lib/phobos_db_checkpoint/events_api_spec.rb
+++ b/spec/lib/phobos_db_checkpoint/events_api_spec.rb
@@ -169,4 +169,24 @@ describe PhobosDBCheckpoint::EventsAPI, type: :db do
       end
     end
   end
+
+  context 'with not found' do
+    it 'returns 404' do
+      get '/v1/not-found'
+      expect(last_response.status).to eql 404
+      expect(last_response.body).to eql Hash(error: true, message: 'not found').to_json
+    end
+  end
+
+  context 'with errors' do
+    it 'returns 500' do
+      expect(PhobosDBCheckpoint::Event)
+        .to receive(:find)
+        .and_raise(StandardError, 'generic error')
+
+      get 'v1/events/1'
+      expect(last_response.status).to eql 500
+      expect(last_response.body).to eql Hash(error: true, message: 'generic error').to_json
+    end
+  end
 end

--- a/spec/lib/phobos_db_checkpoint/events_api_spec.rb
+++ b/spec/lib/phobos_db_checkpoint/events_api_spec.rb
@@ -80,7 +80,7 @@ describe PhobosDBCheckpoint::EventsAPI, type: :db do
       end
     end
 
-    context 'when handler is configured anymore' do
+    context 'when handler is not configured anymore' do
       it 'returns 422' do
         event.group_id = 'another-group'
         event.save

--- a/spec/lib/phobos_db_checkpoint/middleware/database_spec.rb
+++ b/spec/lib/phobos_db_checkpoint/middleware/database_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'phobos_db_checkpoint/middleware/database'
+
+describe PhobosDBCheckpoint::Middleware::Database, type: :db do
+  class TestPhobosDbCheckpointDatabaseMiddlewareApp
+    def call(request_env); end
+  end
+
+  let(:app) { TestPhobosDbCheckpointDatabaseMiddlewareApp.new }
+  let(:request_env) { Hash(PATH_INFO: '/path') }
+  subject { PhobosDBCheckpoint::Middleware::Database.new(app) }
+
+  it 'calls app.call with request_env' do
+    expect(app).to receive(:call).with(request_env)
+    subject.call(request_env)
+  end
+
+  it 'gives access to a connection from the connection pool' do
+    ActiveRecord::Base.clear_active_connections!
+    expect(ActiveRecord::Base.connection_pool.active_connection?).to be_nil
+    expect(app).to receive(:call) do
+      expect(ActiveRecord::Base.connection_pool.active_connection?)
+        .to be_a(ActiveRecord::ConnectionAdapters::AbstractAdapter)
+    end
+    subject.call(request_env)
+  end
+
+  it 'returns db connections back to the connection pool' do
+    expect(ActiveRecord::Base).to receive(:clear_active_connections!)
+    subject.call(request_env)
+  end
+end

--- a/spec/lib/phobos_db_checkpoint/middleware/logger_spec.rb
+++ b/spec/lib/phobos_db_checkpoint/middleware/logger_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+require 'phobos_db_checkpoint/middleware/logger'
+
+describe PhobosDBCheckpoint::Middleware::Logger do
+  class TestPhobosDbCheckpointLoggerMiddlewareApp
+    def call(request_env); end
+  end
+
+  let(:app) { TestPhobosDbCheckpointLoggerMiddlewareApp.new }
+  let(:status) { 200 }
+  let(:headers) { Hash('Content-Length' => 10) }
+  let(:body) { [Hash(message: 'lorem ipsum').to_json] }
+  let(:app_response) { [status, headers, body] }
+  let(:options) { Hash(config: 'spec/phobos.test.yml', log_file: 'spec/log/api.log') }
+
+  subject { PhobosDBCheckpoint::Middleware::Logger.new(app, options) }
+
+  before do
+    FileUtils.rm_rf('spec/log')
+    allow(app).to receive(:call).and_return(app_response)
+  end
+
+  after do
+    FileUtils.rm_rf('spec/log')
+  end
+
+  let :request_env do
+    {
+      'REMOTE_ADDR': '127.0.0.1',
+      'HTTP_VERSION' => '1.1',
+      'PATH_INFO' => '/path',
+      'REQUEST_METHOD' => 'GET',
+      'QUERY_STRING' => 'attr1=val&attr2=val',
+      'CONTENT_LENGTH' => 10
+    }
+  end
+
+  it 'writes the request log to the logger file' do
+    subject.call(request_env).last.close
+    log = JSON.parse(File.read(options[:log_file]))['message']
+
+    expect(log['remote_address']).to eql request_env['REMOTE_ADDR']
+    expect(log['remote_user']).to eql request_env['REMOTE_USER']
+    expect(log['request_method']).to eql request_env['REQUEST_METHOD']
+    expect(log['path']).to eql '/path?attr1=val&attr2=val 1.1'
+    expect(log['status']).to eql '200'
+    expect(log['content_length']).to eql request_env['CONTENT_LENGTH']
+    expect(log['request_time']).to_not be_nil
+  end
+
+  it 'sets "rack.logger" to Phobos.logger' do
+    expect(request_env['rack.logger']).to be_nil
+    subject.call(request_env)
+    expect(request_env['rack.logger']).to eql Phobos.logger
+  end
+
+  context 'when request_env has HTTP_X_FORWARDED_FOR instead of REMOTE_ADDR' do
+    it 'writes remote_address as HTTP_X_FORWARDED_FOR' do
+      subject.call(request_env.merge('HTTP_X_FORWARDED_FOR' => '10.10.10.10')).last.close
+      log = JSON.parse(File.read(options[:log_file]))['message']
+      expect(log['remote_address']).to eql '10.10.10.10'
+    end
+  end
+
+  context 'when "sinatra.error" is defined' do
+    let(:status) { 500 }
+
+    it 'writes the exception' do
+      error = StandardError.new('some error!')
+      subject.call(request_env.merge('sinatra.error' => error)).last.close
+      log = JSON.parse(File.read(options[:log_file]))['message']
+
+      expect(log['status']).to eql '500'
+      expect(log['exception_class']).to eql StandardError.to_s
+      expect(log['exception_message']).to eql error.message
+      expect(log['backtrace']).to eql error.backtrace
+    end
+  end
+end

--- a/spec/lib/phobos_db_checkpoint/middleware/logger_spec.rb
+++ b/spec/lib/phobos_db_checkpoint/middleware/logger_spec.rb
@@ -16,6 +16,7 @@ describe PhobosDBCheckpoint::Middleware::Logger do
   subject { PhobosDBCheckpoint::Middleware::Logger.new(app, options) }
 
   before do
+    Phobos.silence_log = false
     FileUtils.rm_rf('spec/log')
     allow(app).to receive(:call).and_return(app_response)
   end

--- a/spec/lib/phobos_db_checkpoint_spec.rb
+++ b/spec/lib/phobos_db_checkpoint_spec.rb
@@ -13,6 +13,19 @@ RSpec.describe PhobosDBCheckpoint do
 
       PhobosDBCheckpoint.configure
     end
+
+    it 'uses provided pool_size if any' do
+      expect(PhobosDBCheckpoint)
+        .to receive(:load_db_config)
+        .with(pool_size: 3)
+        .and_call_original
+
+      expect(ActiveRecord::Base)
+        .to receive(:establish_connection)
+        .with(hash_including('pool' => 3))
+
+      PhobosDBCheckpoint.configure(pool_size: 3)
+    end
   end
 
   describe '.load_db_config' do
@@ -35,6 +48,15 @@ RSpec.describe PhobosDBCheckpoint do
 
       PhobosDBCheckpoint.load_db_config
       expect(PhobosDBCheckpoint.db_config['pool']).to eql 15
+    end
+
+    it 'uses provided pool_size value if any' do
+      allow(Phobos)
+        .to receive(:config)
+        .and_return(Phobos::DeepStruct.new)
+
+      PhobosDBCheckpoint.load_db_config(pool_size: 3)
+      expect(PhobosDBCheckpoint.db_config['pool']).to eql 3
     end
   end
 

--- a/spec/phobos.test.yml
+++ b/spec/phobos.test.yml
@@ -1,6 +1,6 @@
 logger:
   file: spec/log/phobos.log
-  level: debug
+  level: info
 
 kafka:
   # identifier for this application

--- a/spec/phobos.test.yml
+++ b/spec/phobos.test.yml
@@ -1,0 +1,93 @@
+logger:
+  file: spec/log/phobos.log
+  level: debug
+
+kafka:
+  # identifier for this application
+  client_id: phobos
+  # timeout setting for connecting to brokers
+  connect_timeout:
+  # timeout setting for socket connections
+  socket_timeout:
+  # PEM encoded CA cert to use with an SSL connection (string)
+  ssl_ca_cert:
+  # PEM encoded client cert to use with an SSL connection (string)
+  # Must be used in combination with ssl_client_cert_key
+  ssl_client_cert:
+  # PEM encoded client cert key to use with an SSL connection (string)
+  # Must be used in combination with ssl_client_cert
+  ssl_client_cert_key:
+  # list of brokers used to initialize the client ("port:protocol")
+  seed_brokers:
+    - localhost:9092
+
+producer:
+  # number of seconds a broker can wait for replicas to acknowledge
+  # a write before responding with a timeout
+  ack_timeout: 5
+  # number of replicas that must acknowledge a write, or `:all`
+  # if all in-sync replicas must acknowledge
+  required_acks: :all
+  # number of retries that should be attempted before giving up sending
+  # messages to the cluster. Does not include the original attempt
+  max_retries: 2
+  # number of seconds to wait between retries
+  retry_backoff: 1
+  # number of messages allowed in the buffer before new writes will
+  # raise {BufferOverflow} exceptions
+  max_buffer_size: 1000
+  # maximum size of the buffer in bytes. Attempting to produce messages
+  # when the buffer reaches this size will result in {BufferOverflow} being raised
+  max_buffer_bytesize: 10000000
+  # name of the compression codec to use, or nil if no compression should be performed.
+  # Valid codecs: `:snappy` and `:gzip`
+  compression_codec:
+  # number of messages that needs to be in a message set before it should be compressed.
+  # Note that message sets are per-partition rather than per-topic or per-producer
+  compression_threshold: 1
+  # maximum number of messages allowed in the queue. Only used for async_producer
+  max_queue_size: 1000
+  # if greater than zero, the number of buffered messages that will automatically
+  # trigger a delivery. Only used for async_producer
+  delivery_threshold: 0
+  # if greater than zero, the number of seconds between automatic message
+  # deliveries. Only used for async_producer
+  delivery_interval: 0
+
+consumer:
+  # number of seconds after which, if a client hasn't contacted the Kafka cluster,
+  # it will be kicked out of the group
+  session_timeout: 30
+  # interval between offset commits, in seconds
+  offset_commit_interval: 10
+  # number of messages that can be processed before their offsets are committed.
+  # If zero, offset commits are not triggered by message processing
+  offset_commit_threshold: 0
+  # interval between heartbeats; must be less than the session window
+  heartbeat_interval: 10
+
+backoff:
+  min_ms: 1000
+  max_ms: 60000
+
+listeners:
+  - handler: Phobos::EchoHandler
+    topic: test
+    # id of the group that the consumer should join
+    group_id: test-checkpoint
+    # Number of threads created for this listener, each thread will behave as an independent consumer.
+    # They don't share any state
+    max_concurrency: 1
+    # Once the consumer group has checkpointed its progress in the topic's partitions,
+    # the consumers will always start from the checkpointed offsets, regardless of config
+    # As such, this setting only applies when the consumer initially starts consuming from a topic
+    start_from_beginning: true
+    # maximum amount of data fetched from a single partition at a time
+    max_bytes_per_partition: 524288 # 512 KB
+    # Minimum number of bytes to read before returning messages from the server; if `max_wait_time` is reached, this is ignored.
+    min_bytes: 1
+    # Maximum duration of time to wait before returning messages from the server, in seconds
+    max_wait_time: 5
+    # Apply this encoding to the message payload, if blank it uses the original encoding. This property accepts values
+    # defined by the ruby Encoding class (https://ruby-doc.org/core-2.3.0/Encoding.html). Ex: UTF_8, ASCII_8BIT, etc
+    force_encoding:

--- a/templates/config.ru
+++ b/templates/config.ru
@@ -1,0 +1,17 @@
+require 'bundler/setup'
+require 'phobos_db_checkpoint'
+require 'phobos_db_checkpoint/events_api'
+require_relative './phobos_boot.rb'
+
+logger_config = {
+  # config: 'config/phobos.yml'
+  # log_file: 'log/api.log'
+}
+
+database_config = {
+  # pool_size: PhobosDBCheckpoint::DEFAULT_POOL_SIZE # 5
+}
+
+use PhobosDBCheckpoint::Middleware::Logger, logger_config
+use PhobosDBCheckpoint::Middleware::Database, database_config
+run PhobosDBCheckpoint::EventsAPI


### PR DESCRIPTION
This PR adds a small sinatra app to expose an API for events. The API contains:
* event by id
* retry of a single event
* list by entity_id, group_id, topic and event_type with pagination
* ping

It comes with a new cli command to create a `config.ru` in the host project (`phobos_db_checkpoint init_events_api`). The sinatra part is lazy and is not loaded in the regular flow, only through the `config.ru`.

I've been discussing this with @ticolucci for a while, so take a look and see if you guys like it.