### PR TITLE
Add index required for current implementation of phobos checkpoint ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.3.1 (2017-03-11)
+
+- [bugfix] Add index required for current implementation of Phobos Checkpoint UI
+
 ## 2.3.0 (2017-03-08)
 
 - [enhancement] Add created_at to events table

--- a/lib/phobos_db_checkpoint/version.rb
+++ b/lib/phobos_db_checkpoint/version.rb
@@ -1,3 +1,3 @@
 module PhobosDBCheckpoint
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end

--- a/templates/migrate/phobos_04_create_events_api_index.rb.erb
+++ b/templates/migrate/phobos_04_create_events_api_index.rb.erb
@@ -1,5 +1,6 @@
 class Phobos04CreateEventsApiIndex < ActiveRecord::Migration[<%= ActiveRecord::VERSION::STRING.to_f %>]
   def up
+    say 'Adding events api indices'
     add_index :phobos_db_checkpoint_events,
       [:event_time, :created_at],
       name: :phobos_events_event_time_created_at_desc_nulls_last_idx,
@@ -11,10 +12,42 @@ class Phobos04CreateEventsApiIndex < ActiveRecord::Migration[<%= ActiveRecord::V
       name: :phobos_failures_event_time_created_at_desc_nulls_last_idx,
       order: {event_time: 'desc nulls last', created_at: 'desc nulls last'},
       using: :btree
+
+    say 'Removing unused indices'
+    remove_index :phobos_db_checkpoint_events, name: :phobos_events_event_time_desc_nulls_last_idx
+    remove_index :phobos_db_checkpoint_events, name: :phobos_events_created_at_desc_nulls_last_idx
+    remove_index :phobos_db_checkpoint_failures, name: :phobos_failures_event_time_desc_nulls_last_idx
+    remove_index :phobos_db_checkpoint_failures, name: :phobos_failures_created_at_desc_nulls_last_idx
   end
 
   def down
+    say 'Removing new events api indices'
     remove_index :phobos_db_checkpoint_events, name: :phobos_events_event_time_created_at_desc_nulls_last_idx
     remove_index :phobos_db_checkpoint_failures, name: :phobos_failures_event_time_created_at_desc_nulls_last_idx
+
+    say 'Adding old indices back'
+    add_index :phobos_db_checkpoint_events,
+      [:event_time],
+      name: :phobos_events_event_time_desc_nulls_last_idx,
+      order: {event_time: 'desc nulls last'},
+      using: :btree
+
+    add_index :phobos_db_checkpoint_events,
+      [:created_at],
+      name: :phobos_events_created_at_desc_nulls_last_idx,
+      order: {created_at: 'desc nulls last'},
+      using: :btree
+
+    add_index :phobos_db_checkpoint_failures,
+      [:event_time],
+      name: :phobos_failures_event_time_desc_nulls_last_idx,
+      order: {event_time: 'desc nulls last'},
+      using: :btree
+
+    add_index :phobos_db_checkpoint_failures,
+      [:created_at],
+      name: :phobos_failures_created_at_desc_nulls_last_idx,
+      order: {created_at: 'desc nulls last'},
+      using: :btree
   end
 end

--- a/templates/migrate/phobos_04_create_events_api_index.rb.erb
+++ b/templates/migrate/phobos_04_create_events_api_index.rb.erb
@@ -1,0 +1,20 @@
+class Phobos04CreateEventsApiIndex < ActiveRecord::Migration[<%= ActiveRecord::VERSION::STRING.to_f %>]
+  def up
+    add_index :phobos_db_checkpoint_events,
+      [:event_time, :created_at],
+      name: :phobos_events_event_time_created_at_desc_nulls_last_idx,
+      order: {event_time: 'desc nulls last', created_at: 'desc nulls last'},
+      using: :btree
+
+    add_index :phobos_db_checkpoint_failures,
+      [:event_time, :created_at],
+      name: :phobos_failures_event_time_created_at_desc_nulls_last_idx,
+      order: {event_time: 'desc nulls last', created_at: 'desc nulls last'},
+      using: :btree
+  end
+
+  def down
+    remove_index :phobos_db_checkpoint_events, name: :phobos_events_event_time_created_at_desc_nulls_last_idx
+    remove_index :phobos_db_checkpoint_failures, name: :phobos_failures_event_time_created_at_desc_nulls_last_idx
+  end
+end


### PR DESCRIPTION
Fixes #26

### Before
````
myDB=> EXPLAIN select * from events order by event_time desc nulls last, created_at DESC NULLS LAST limit 20;
                                   QUERY PLAN
--------------------------------------------------------------------------------
 Limit  (cost=520598.01..520598.06 rows=20 width=1072)
   ->  Sort  (cost=520598.01..527267.97 rows=2667986 width=1072)
         Sort Key: event_time DESC NULLS LAST, created_at DESC NULLS LAST
         ->  Seq Scan on events  (cost=0.00..449603.86 rows=2667986 width=1072)
(4 rows)
````

### This migration adds:

````
CREATE INDEX phobos_events_event_time_created_at_desc_nulls_last_idx
  ON public.phobos_db_checkpoint_events
  USING btree
  (event_time DESC NULLS LAST, created_at DESC NULLS LAST);
````

### After

````
myDB=> EXPLAIN select * from events order by event_time desc nulls last, created_at DESC NULLS LAST limit 20;
                                            QUERY PLAN
--------------------------------------------------------------------------------------------------
 Limit  (cost=0.43..42.29 rows=20 width=1072)
   ->  Index Scan using nulls_last_idx on events  (cost=0.43..5584645.73 rows=2667986 width=1072)
(2 rows)
````

