### PR TITLE
Refactor tests to use test handler provided by phobos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## UNRELEASED
 ### Changed
 - Introduce rubocop style guide
+- Use test module from Phobos to run handler specs
 
 ## 3.3.0 (2017-10-26)
 

--- a/spec/lib/phobos_db_checkpoint/handler_spec.rb
+++ b/spec/lib/phobos_db_checkpoint/handler_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe PhobosDBCheckpoint::Handler, type: :db do
   let(:event_type) { 'event-type' }
   let(:event_version) { 'v1' }
 
+  before do
+    allow(TestPhobosDbCheckpointHandler).to receive(:new).and_return(handler)
+  end
+
   it 'exposes Phobos::Handler.start' do
     expect(TestPhobosDbCheckpointHandler).to respond_to :start
   end
@@ -40,9 +44,7 @@ RSpec.describe PhobosDBCheckpoint::Handler, type: :db do
     let(:metadata) { Hash(topic: topic, group_id: group_id) }
 
     def run_handler
-      TestPhobosDbCheckpointHandler.around_consume(payload, metadata) do
-        handler.consume(payload, metadata)
-      end
+      process_message(handler: TestPhobosDbCheckpointHandler, payload: payload, metadata: metadata)
     end
 
     describe 'when returning ack' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'bundler/setup'
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'phobos_db_checkpoint'
+require 'phobos/test'
 
 require 'fileutils'
 require 'pry-byebug'
@@ -53,6 +54,8 @@ DatabaseCleaner.strategy = :truncation
 DatabaseCleaner::ActiveRecord.config_file_location = PhobosDBCheckpoint.db_config
 
 RSpec.configure do |config|
+  config.include Phobos::Test::Helper
+
   config.before(:context, standalone: true) do
     ActiveRecord::Base.connection.disconnect!
   end


### PR DESCRIPTION
It is far better to use the test helper provided by phobos than trying to brew your own. Doing it this way will make test run closer to reality and also detect breaking changes and deprecation warnings in phobos which would otherwise not be caught.